### PR TITLE
Fixes eclipse-emfcloud#55: Incorrect ChangeModel

### DIFF
--- a/modelserver-theia/src/common/change-model.ts
+++ b/modelserver-theia/src/common/change-model.ts
@@ -60,7 +60,7 @@ export class ResourceChange extends ModelServerObject {
 
 export class FeatureChange {
     static readonly URI = ChangePackage.NS_URI + '#//FeatureChange';
-    eClass = ChangeDescription.URI;
+    eClass = FeatureChange.URI;
 
     featureName?: string;
     dataValue?: string;
@@ -73,7 +73,7 @@ export class FeatureChange {
 
 export class EObjectToChangesMapEntry extends ModelServerObject {
     static readonly URI = ChangePackage.NS_URI + '#//EObjectToChangesMapEntry';
-    eClass = ChangeDescription.URI;
+    eClass = EObjectToChangesMapEntry.URI;
 
     key: ModelServerReferenceDescription;
     value?: FeatureChange[];


### PR DESCRIPTION
Fixing incorrect EClasses which prevent from using the ChangeModel and its 'is' methods.